### PR TITLE
Remove default title on legends

### DIFF
--- a/src/views/Visualizer/View/View.js
+++ b/src/views/Visualizer/View/View.js
@@ -219,7 +219,7 @@ export class Visualizer extends React.Component {
         if (layer.sublayers) {
           const selected = state.sublayers.findIndex(active => active);
           const selectedSublayer = layer.sublayers[selected];
-          return selectedSublayer && selectedSublayer.legends && selectedSublayer.legends;
+          return selectedSublayer && selectedSublayer.legends;
         }
         return layer.legends && layer.legends;
       })

--- a/src/views/Visualizer/View/View.js
+++ b/src/views/Visualizer/View/View.js
@@ -221,7 +221,7 @@ export class Visualizer extends React.Component {
           const selectedSublayer = layer.sublayers[selected];
           return selectedSublayer && selectedSublayer.legends;
         }
-        return layer.legends && layer.legends;
+        return layer.legends;
       })
       .filter(defined => defined)
       .reduce((accum, legendsCluster) => [

--- a/src/views/Visualizer/View/View.js
+++ b/src/views/Visualizer/View/View.js
@@ -219,18 +219,12 @@ export class Visualizer extends React.Component {
         if (layer.sublayers) {
           const selected = state.sublayers.findIndex(active => active);
           const selectedSublayer = layer.sublayers[selected];
-          return selectedSublayer && selectedSublayer.legends && ({
-            title: selectedSublayer.label,
-            legendsCluster: selectedSublayer.legends,
-          });
+          return selectedSublayer && selectedSublayer.legends && selectedSublayer.legends;
         }
-        return layer.legends && ({
-          title: layer.label,
-          legendsCluster: layer.legends,
-        });
+        return layer.legends && layer.legends;
       })
       .filter(defined => defined)
-      .reduce((accum, { legendsCluster }) => [
+      .reduce((accum, legendsCluster) => [
         ...accum,
         ...legendsCluster.reduce((acc, legend) => [...acc, { ...legend }], []),
       ], []);

--- a/src/views/Visualizer/View/View.js
+++ b/src/views/Visualizer/View/View.js
@@ -230,9 +230,9 @@ export class Visualizer extends React.Component {
         });
       })
       .filter(defined => defined)
-      .reduce((accum, { legendsCluster, title }) => [
+      .reduce((accum, { legendsCluster }) => [
         ...accum,
-        ...legendsCluster.reduce((acc, legend) => [...acc, { title, ...legend }], []),
+        ...legendsCluster.reduce((acc, legend) => [...acc, { ...legend }], []),
       ], []);
 
     return [...(legends || []), ...(legendsFromLayersTree || [])];


### PR DESCRIPTION
By default if there's no legend title, the title of the layer is used as placeholder.

We want the possibility for legends to have no titles at all so it seems a bit useless.

I don't think there's a case where we actually want that?

This PR goes with https://github.com/Terralego/terra-admin/pull/531 and https://github.com/Terralego/terra-front/pull/325