### PR TITLE
Fix invisible splash-screen catching clicks

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -11,6 +11,7 @@ body {
   background-color: #394B59;
 }
 .splash-screen_container {
+  pointer-events: none;
   opacity: 0;
   transition: opacity 1s ease-in;
   position: absolute;


### PR DESCRIPTION
When the app loads (or reloads when developping 😡), the UI is unresponsive for 5 seconds.

That's because it's how long the splash screen is in the DOM. Even if it is empty.

There's another way to fix that (which avoids the problem of user being able to click stuff they don't see if there's a splash screen), change the timeout here https://github.com/Terralego/visu-front/blob/791c7831d6fb1c6b3e77c4bb1c44d753d5a83777/src/views/Main/Content/SplashScreen.js#L9
 
The splascreen opacity transition is one second, so changing the timeout to anything between 1000 and 1500 seems ok.

**But** if there's no splash screen, the UI will still be unresponsive for 1 or 1.5 seconds. Should we test if the splashscreen exists and set the timeout to 0?

In the meantime, this solution works really well for cheap.