### PR TITLE
Create upgrade-terralego-core.yml

### DIFF
--- a/.github/workflows/upgrade-terralego-core.yml
+++ b/.github/workflows/upgrade-terralego-core.yml
@@ -1,0 +1,44 @@
+name: Upgrade @terralego/core
+
+on: [workflow_dispatch]
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+
+jobs:
+  tests:
+    name: Upgrade @terralego/core
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: ./node_modules
+          key: node-modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: |
+          npm ci
+          
+      - name: Upgrade core
+        run: |
+          npm install @terralego/core@latest
+
+      - name: Build
+        run: |
+          npx react-scripts build
+
+      - name: Add & Commit
+        uses: EndBug/add-and-commit@v9.1.3
+        with:
+          add: 'package-lock.json package.json'
+          message: 'Bump @terralego/core'
+          new_branch: 'upgrade-terralego-core'

--- a/.github/workflows/upgrade-terralego-core.yml
+++ b/.github/workflows/upgrade-terralego-core.yml
@@ -42,3 +42,9 @@ jobs:
           add: 'package-lock.json package.json'
           message: 'Bump @terralego/core'
           new_branch: 'upgrade-terralego-core'
+
+      - name: Create pull request
+        uses: devops-infra/action-pull-request@v0.5.5
+        with:
+          title: "Bump @terralego/core"
+          source_branch: 'upgrade-terralego-core'


### PR DESCRIPTION
Draft of a GitHub Action to upgrade @terralego/core then create a pull request with the updated package.json and package-lock.json

At first, we can launch it manually in the actions tab, we'll see about automatisation next.

Tried to run it on my computer with https://github.com/nektos/act, seems to work but it stopped at pushing, I guess because of auth.

I left the default Author and Mail for commits, don't know what to add there.

For the pull request action, a GitHub Token is required, I guess to know what "user" should open the PR. Not sure what to add here, do we have a generic Terralego user that can be used?
I'll use my account for tests of course but that's not a good idea long term.