### PR TITLE
Get splashscreen from backend settings

### DIFF
--- a/src/views/Main/Content/SplashScreen.js
+++ b/src/views/Main/Content/SplashScreen.js
@@ -1,14 +1,24 @@
 import { useEffect } from 'react';
+import { connectSettings } from '../Provider/context';
 
-export const SplashScreen = ({ children }) => {
+export const SplashScreen = ({ children, settings }) => {
   useEffect(() => {
     document.body.classList.remove('with-splash');
-    setTimeout(() => {
+    const removeSplash = () => {
       const splashScreen = document.querySelector('.splash-screen_container');
       splashScreen && splashScreen.remove();
+    };
+    if (settings?.theme?.splashScreenEnabled && settings?.theme?.splashScreen) {
+      const splashScreenImg = document.createElement('img');
+      splashScreenImg.src = settings?.theme?.splashScreen;
+      const splashScreenElement = document.querySelector('.splash-screen_container > .splash-screen');
+      splashScreenElement && splashScreenElement.appendChild(splashScreenImg);
+    }
+    setTimeout(() => {
+      removeSplash();
     }, 5000);
-  }, []);
+  }, [settings]);
   return children;
 };
 
-export default SplashScreen;
+export default connectSettings('settings')(SplashScreen);


### PR DESCRIPTION
Is there's an enabled splashscreen in the settings, use this as a splash-screen.

If a splashscreen if defined directly in the index.html, the legacy way, it isn't touched as long as there isn't also one in the settings.