### PR TITLE
Change splashscreen timing + fix double splashcreen bug

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -11,6 +11,8 @@ body {
   background-color: #394B59;
 }
 .splash-screen_container {
+  background-color: #0000004f;
+  backdrop-filter: blur(3px);
   pointer-events: none;
   opacity: 0;
   transition: opacity 1s ease-in;

--- a/src/views/Main/Content/SplashScreen.js
+++ b/src/views/Main/Content/SplashScreen.js
@@ -3,19 +3,26 @@ import { connectSettings } from '../Provider/context';
 
 export const SplashScreen = ({ children, settings }) => {
   useEffect(() => {
-    document.body.classList.remove('with-splash');
-    const removeSplash = () => {
+    const hideSplash = () => {
+      document.body.classList.remove('with-splash');
+    };
+    const unmountSplash = () => {
       const splashScreen = document.querySelector('.splash-screen_container');
       splashScreen && splashScreen.remove();
     };
     if (settings?.theme?.splashScreenEnabled && settings?.theme?.splashScreen) {
+      const existingImg = document.querySelector('.splash-screen_container img');
+      existingImg && existingImg.remove();
       const splashScreenImg = document.createElement('img');
       splashScreenImg.src = settings?.theme?.splashScreen;
       const splashScreenElement = document.querySelector('.splash-screen_container > .splash-screen');
       splashScreenElement && splashScreenElement.appendChild(splashScreenImg);
     }
     setTimeout(() => {
-      removeSplash();
+      hideSplash();
+    }, 2000);
+    setTimeout(() => {
+      unmountSplash();
     }, 5000);
   }, [settings]);
   return children;


### PR DESCRIPTION
Splashscreen now stays 2 seconds before triggering the fade-out effect.

Remove the splashscreen img before adding it, sometimes the img is appended two times, maybe because of double renders.

Added a small backdrop to the splashscreen to make the splash img stand out.